### PR TITLE
DOC: remove invalid codetools doc.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'ETS'
-copyright = '2008, Enthought'
+copyright = '2008-2014, Enthought'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,35 +1,7 @@
-.. CodeTools documentation master file, created by sphinx-quickstart on Tue Jul 22 09:56:01 2008.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to the CodeTools documentation!
-=======================================
-
-The CodeTools project provide a series of modules for analysis and control of
-code execution. The key components are Blocks, sections of code to execute,
-and Contexts, dictionary-like objects which are used as namespaces for Block
-execution. CodeTools is designed to perform such tasks as:
-
-- executing code in a controlled environment
-- performing dependency analysis on code so that expensive recalculations
-  can be avoided
-- having Traits-aware code listen for changes inside the namespace of
-  executing code
-- automatically converting or adapting variables on access from, or
-  assignment to, a namespace
-
-CodeTools depends upon Traits, with an optional dependency on SciMath and
-Numpy for unit support, but has no major dependencies beyond that.
-
-CodeTools is under active development, so the implementation and API are
-somewhat fluid.
+Welcome to the ETS documentation!
+=================================
 
 Contents
 --------
 
 .. toctree::
-   
-   tutorial.rst
-   roadmap.rst
-
-


### PR DESCRIPTION
We kept the doc template, though.

@mdickinson this should fix what you mentioned in #12
