### PR TITLE
Adding Qt_binder and enable_mapping to the list of packages to manage…

### DIFF
--- a/ets.py
+++ b/ets.py
@@ -92,7 +92,7 @@ ets_package_names = """\
       pyface             traitsui           codetools
       scimath            enable             apptools
       envisage           chaco              mayavi
-      graphcanvas"""
+      graphcanvas        qt_binder          enable-mapping"""
 
 ets_ssh = "git@github.com:enthought/%s.git"
 ets_https = "https://github.com/enthought/%s.git"


### PR DESCRIPTION
… when people download ETS.

Based on recent conversation with clients, Qt_binder is becoming a package that people find critical to embrace the suite. Enable-mapping isn't receiving a lot of care but is solving a whole new class of problems. I would advertise for that...