### PR TITLE
EEP 7: ETS Code Modernization

### DIFF
--- a/docs/source/eeps/eep-0.rst
+++ b/docs/source/eeps/eep-0.rst
@@ -87,6 +87,7 @@ EEP                      EEP Title
 `EEP-4 <eep-4.html>`_    Type Annotation Integration
 `EEP-5 <eep-5.html>`_    TraitsUI Tables and Trees
 `EEP-6 <eep-6.html>`_    Whither Apptools?
+`EEP-7 <eep-7.html>`_    ETS Code Modernization
 ======================== =====================================================
 
 

--- a/docs/source/eeps/eep-4.rst
+++ b/docs/source/eeps/eep-4.rst
@@ -56,9 +56,9 @@ to Traits, and would not permit existing code to enjoy the benefits of
 type annotation.
 
 Additionally, there has been substantial change in the design of standard
-library support for type annotations (particularly the :module:`typing`
+library support for type annotations (particularly the :mod:`typing`
 module) through the supported versions of Python (currently 3.5 to 3.8).
-This provides technical obstacles in mapping complex :module:`typing` types
+This provides technical obstacles in mapping complex :mod:`typing` types
 to corresponding Traits types.
 
 Finally, because the :class:`HasMetaTraits` class manipulates the structure
@@ -94,7 +94,7 @@ following restrictions:
   discourage the use of bare classes like ``Int``, as supporting this adds
   some complexity to the codebase.
 - for classes with inner traits eg. :class:`List(Int)` we may initially simply
-  annotate as :class:`list` rather than using the full :module:`typing` module
+  annotate as :class:`list` rather than using the full :mod:`typing` module
   ``List[int]``.  A partial, but true, annotation is better than a complex and
   complete annotation, at least initially.  However initial experimentation
   indicates that it should be possible to cover the inner types.
@@ -103,7 +103,7 @@ following restrictions:
 
 This will require some auxilliary type definitions (and likely some generic
 types) to describe these situations, but should not require any deep work
-with the :module:`typing` module.
+with the :mod:`typing` module.
 
 Since developing the stub files is an iterative process which is likely to
 proceed quickly initially, we do not want to be tied to the Traits release
@@ -117,7 +117,7 @@ the issue of keeping stubs synchronized with the traits release.
 We won't be able to give typing hints for:
 
 - ``**traits`` keyword arguments: if a user wants this they will need to
-  express it themselves in the signature of the :method:`__init__` as the
+  express it themselves in the signature of the :meth:`__init__` as the
   typing system has no way to link the keyword arguments with particular
   named attributes.  Fortunately these will be run-time type-checked.
 - overloaded defaults of the form::
@@ -141,7 +141,7 @@ Implementation
 
 A reasonable initial step may be to use stub generation tools to generate
 stub files for most of the modules.  However most of the work will need to
-be done with the :module:`traits.trait_types` module, since those need to
+be done with the :mod:`traits.trait_types` module, since those need to
 be converted into something that represents the value type (eg. int, str,
 list, etc.) rather than the ``TraitType`` object.
 

--- a/docs/source/eeps/eep-7.rst
+++ b/docs/source/eeps/eep-7.rst
@@ -13,7 +13,7 @@ EEP 7: ETS Code Modernization
 Introduction
 ============
 
-All of the ETS codebase, with the exeption of the Codetools module,
+All of the ETS codebase, with the exception of the Codetools module,
 supports Python 3.  With the end-of-life of Python 2 in 2020, we want
 to move to a Python 3-only codebase.
 

--- a/docs/source/eeps/eep-7.rst
+++ b/docs/source/eeps/eep-7.rst
@@ -1,0 +1,110 @@
+=============================
+EEP 7: ETS Code Modernization
+=============================
+
+:Author: Corran Webster
+:Status: Active
+:Type: Standards Track
+:Content-Type: text/x-rst
+:Created: 2020-10-07
+:Post-History: 2020-10-07
+
+
+Introduction
+============
+
+All of the ETS codebase, with the exeption of the Codetools module,
+supports Python 3.  With the end-of-life of Python 2 in 2020, we want
+to move to a Python 3-only codebase.
+
+Additionally, we would like to make use of some of the new features of
+Traits 6.1 and remove things which were deprecated in Traits 6.0 and 6.1.
+In doing this we want to minimize the disruption to other codebases.
+
+This also presents a plan for dropping support for old versions of the
+GUI toolkits (Qt 4, WxPython < 4.1).
+
+Motivation
+==========
+
+ETS is a codebase with roots that go back 15 years.  As a result there
+is a lot of old code that either doesn't take advantage of new features,
+or which is overly complicated because it needs to take into account the
+changes in behaviour of code over the past decade and a half.
+
+Currently the codebase supports Python 2.7 and 3.5+ in most cases, with
+the notable exception of Codetools.
+
+Supporting Python 2 requires additional effort from the ETS maintainers
+and becomes more and more difficult as Python 3 progresses, preventing
+us from using new libraries and features in Python 3.  This has already
+been done for Traits 6.0, TraitsUI 7.0, Pyface 7.0 and Envisage (not yet
+released), and has seen payoff in terms of code simplicity and quality.
+
+Traits 6.1 presents a new observable framework, trait types and better
+container objects which resolve a number of issues with the solutions
+in Traits 6.0 and before.  There are some improvements to these scheduled
+for Traits 6.2 that we may want to take advantage of as they will make the
+transition from old code easier.
+
+We have support in the GUI code for releases of the underlying
+toolkits which have not been in use for many years.  Just as supporting
+Python 2 causes extra effort, so does supporting these older versions
+the toolkit.
+
+Finally, the ETS codebase has a mix of code styles and conventions
+used over the years.  Part of this modernization should be to use tools
+like ``black`` to make sure that ETS passes Flake8 and matches the
+`EEP-1 style guide. <eep-1.html>`_  Consistent code style reduces support
+effort and makes a codebase more pleasant to work with.
+
+Proposal
+========
+
+This proposal talks about the development of the following ETS libraries:
+
+- Envisage (current version 4.9.2)
+- Apptools (current version 4.5.0)
+- Enable (current version 4.8.1)
+- Chaco (current version 4.8.0)
+- Mayavi (current version 4.7.2)
+- Scimath (current version 4.2.0)
+- Graphcanvas (current version 4.1.0)
+
+We might also use this process for Codetools, but the effort there is
+likely to be larger since it is more closely bound to the syntax of Python
+by the nature of the library.
+
+We propose to support all Python versions that are not yet end-of-life.
+At the time of writing this is Python 3.6 through to Python 3.9.  All
+new code should support this range of Python versions, and we should no
+longer write any new Python 2 code.
+
+All ETS projects which have not yet dropped Python 2 support will do so
+in their next major release, which is release 5.0 for all these libraries.
+
+We propose that the next major release of all ETS projects should work
+with Traits 6.0, 6.1 and 6.2.  This means that they will not be able to
+take advantage of new features of Traits, but hopefully smooths migration
+paths.
+
+The minor release after that, 5.1, should drop support for Traits 6.0 and
+6.1 and should as much as possible remove everything that has been
+deprecated in Traits 6.0.
+
+We propose that for all ETS projects that have not yet dropped Python 2
+support that the next major release should support Qt 4.8, Qt 5.6+, and
+WxPython 4.0+ as much as possible.  This will likely require modernization
+of any WxPython code that these libraries contain, and possibly some minor
+fixes to Qt code, but is not likely to be a major effort.
+
+The releases for Pyface 7.2 and TraitsUI 7.2 should drop support for Qt
+versions earlier than 5.6 and WxPython 4.0.  This will likely have little
+downstream impact, but libraries might also choose to make this change in
+their 5.2 releases if they have Qt or Wx-specific code.
+
+Finally, as part of code clean-up, re-formatting to match modern code
+style should be done opportunistically during the modernization process.
+In particular, bulk clean-up, like running ``black`` over a codebase should
+be done at a point where there are not a lot of open PRs, to reduce the
+impact from merge conflicts from re-formatting operations.

--- a/docs/source/eeps/eep-7.rst
+++ b/docs/source/eeps/eep-7.rst
@@ -18,8 +18,9 @@ supports Python 3.  With the end-of-life of Python 2 in 2020, we want
 to move to a Python 3-only codebase.
 
 Additionally, we would like to make use of some of the new features of
-Traits 6.1 and remove things which were deprecated in Traits 6.0 and 6.1.
-In doing this we want to minimize the disruption to other codebases.
+Traits 6.1 and remove the usage of things like ``TraitHandlers`` which
+were deprecated in Traits 6.0 and 6.1.  In doing this we want to minimize
+the disruption to other codebases.
 
 This also presents a plan for dropping support for old versions of the
 GUI toolkits (Qt 4, WxPython < 4.1).
@@ -33,7 +34,8 @@ or which is overly complicated because it needs to take into account the
 changes in behaviour of code over the past decade and a half.
 
 Currently the codebase supports Python 2.7 and 3.5+ in most cases, with
-the notable exception of Codetools.
+the notable exception of Codetools, which has substantial components which
+need to be re-written for Python 3.
 
 Supporting Python 2 requires additional effort from the ETS maintainers
 and becomes more and more difficult as Python 3 progresses, preventing
@@ -73,7 +75,8 @@ This proposal talks about the development of the following ETS libraries:
 
 We might also use this process for Codetools, but the effort there is
 likely to be larger since it is more closely bound to the syntax of Python
-by the nature of the library.
+by the nature of the library, and as a result will likely be upgraded
+next year and as a separate effort.
 
 We propose to support all Python versions that are not yet end-of-life.
 At the time of writing this is Python 3.6 through to Python 3.9.  All
@@ -96,7 +99,9 @@ We propose that for all ETS projects that have not yet dropped Python 2
 support that the next major release should support Qt 4.8, Qt 5.6+, and
 WxPython 4.0+ as much as possible.  This will likely require modernization
 of any WxPython code that these libraries contain, and possibly some minor
-fixes to Qt code, but is not likely to be a major effort.
+fixes to Qt code, but is not likely to be a major effort.  Enable is the
+library which is most likely to have work to do here, as it is the library
+with the most Wx-specific code that needs updating.
 
 The releases for Pyface 7.2 and TraitsUI 7.2 should drop support for Qt
 versions earlier than 5.6 and WxPython 4.0.  This will likely have little
@@ -107,4 +112,5 @@ Finally, as part of code clean-up, re-formatting to match modern code
 style should be done opportunistically during the modernization process.
 In particular, bulk clean-up, like running ``black`` over a codebase should
 be done at a point where there are not a lot of open PRs, to reduce the
-impact from merge conflicts from re-formatting operations.
+impact from merge conflicts from re-formatting operations.  Once this is
+done, CI should check to ensure flake8 tests continue to pass.

--- a/docs/source/eeps/index.rst
+++ b/docs/source/eeps/index.rst
@@ -10,3 +10,7 @@ ETS Enhancement Proposals
     eep-1.rst
     eep-2.rst
     eep-3.rst
+    eep-4.rst
+    eep-5.rst
+    eep-6.rst
+    eep-7.rst


### PR DESCRIPTION
A quick EEP on the proposed process of updating to remove Python 2 and start using features from Traits 6.1+